### PR TITLE
SAML認証OFFのログインURLを使用する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function init(
   const kintoneUrl = `https://${domain}/`;
   try {
     console.log(`Open ${kintoneUrl}`);
-    await page.goto(kintoneUrl);
+    await page.goto(`${kintoneUrl}login?saml=off`);
 
     await page.waitFor('.form-username-slash');
     console.log('Try to logged-in...');


### PR DESCRIPTION
SAML認証が有効化されている場合に IdPのログイン画面へ飛ばされてしまい
ログインできないため、SAMLを使用しないログインURLでログインするように
しました。
